### PR TITLE
fixed demo link typo in the readme file

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 Lightweight wrapper around [Loaders.css](https://github.com/ConnorAtherton/loaders.css).
 
-[Demo](http://jonjaques.github.com/react-loaders)
+[Demo](http://jonjaques.github.io/react-loaders)
 
 ## Install
 


### PR DESCRIPTION
The demo link in the readme page was corrected to the correct URL.